### PR TITLE
Log exceptions from activities

### DIFF
--- a/Kerbee/Functions/GetApplicationsActivity.cs
+++ b/Kerbee/Functions/GetApplicationsActivity.cs
@@ -10,21 +10,23 @@ using Microsoft.Extensions.Logging;
 namespace Kerbee.Functions;
 
 [DurableTask(nameof(GetApplicationsActivity))]
-public class GetApplicationsActivity : TaskActivity<object, IEnumerable<Application>>
+public class GetApplicationsActivity(
+    ILogger<GetApplicationsActivity> logger,
+    IApplicationService applicationService) : TaskActivity<object, IEnumerable<Application>>
 {
-    private readonly ILogger _logger;
-    private readonly IApplicationService _applicationService;
+    private readonly ILogger _logger = logger;
+    private readonly IApplicationService _applicationService = applicationService;
 
-    public GetApplicationsActivity(
-        ILogger<GetApplicationsActivity> logger,
-        IApplicationService applicationService)
+    public override async Task<IEnumerable<Application>> RunAsync(TaskActivityContext context, object input)
     {
-        _logger = logger;
-        _applicationService = applicationService;
-    }
-
-    public async override Task<IEnumerable<Application>> RunAsync(TaskActivityContext context, object input)
-    {
-        return await _applicationService.GetApplicationsAsync();
+        try
+        {
+            return await _applicationService.GetApplicationsAsync();
+        }
+        catch (System.Exception ex)
+        {
+            _logger.LogError(ex, "Error getting applications");
+            throw;
+        }
     }
 }

--- a/Kerbee/Functions/PurgeExpiredKeysActivity.cs
+++ b/Kerbee/Functions/PurgeExpiredKeysActivity.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 using Kerbee.Graph;
 using Kerbee.Models;
@@ -9,22 +10,24 @@ using Microsoft.Extensions.Logging;
 namespace Kerbee.Functions;
 
 [DurableTask(nameof(PurgeExpiredKeysActivity))]
-public class PurgeExpiredKeysActivity : TaskActivity<Application, object>
+public class PurgeExpiredKeysActivity(
+    ILogger<PurgeExpiredKeysActivity> logger,
+    IApplicationService applicationService) : TaskActivity<Application, object>
 {
-    private readonly ILogger _logger;
-    private readonly IApplicationService _applicationService;
+    private readonly ILogger _logger = logger;
+    private readonly IApplicationService _applicationService = applicationService;
 
-    public PurgeExpiredKeysActivity(
-        ILogger<PurgeExpiredKeysActivity> logger,
-        IApplicationService applicationService)
+    public override async Task<object> RunAsync(TaskActivityContext context, Application application)
     {
-        _logger = logger;
-        _applicationService = applicationService;
-    }
-
-    public async override Task<object> RunAsync(TaskActivityContext context, Application application)
-    {
-        await _applicationService.PurgeKeys(application);
-        return new();
+        try
+        {
+            await _applicationService.PurgeKeys(application);
+            return new();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error purging keys for application {ApplicationId}", application.Id);
+            throw;
+        }
     }
 }

--- a/Kerbee/Functions/UpdateApplicationsActivity.cs
+++ b/Kerbee/Functions/UpdateApplicationsActivity.cs
@@ -1,27 +1,34 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 using Kerbee.Graph;
 
 using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
 
 namespace Kerbee.Functions;
 
 [DurableTask(nameof(UpdateApplicationsActivity))]
-public class UpdateApplicationsActivity : TaskActivity<object, object>
+public class UpdateApplicationsActivity(
+    IApplicationService applicationService,
+    ILogger<UpdateApplicationsActivity> logger) : TaskActivity<object, object>
 {
-    private readonly IApplicationService _applicationService;
+    private readonly IApplicationService _applicationService = applicationService;
+    private readonly ILogger<UpdateApplicationsActivity> _logger = logger;
 
-    public UpdateApplicationsActivity(IApplicationService applicationService)
-    {
-        _applicationService = applicationService;
-    }
-
-    public async override Task<object> RunAsync(
+    public override async Task<object> RunAsync(
         TaskActivityContext context,
         object input)
     {
-        await _applicationService.UpdateApplications();
-
-        return new object();
+        try
+        {
+            await _applicationService.UpdateApplications();
+            return new object();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating applications");
+            throw;
+        }
     }
 }

--- a/Kerbee/Kerbee.csproj
+++ b/Kerbee/Kerbee.csproj
@@ -9,26 +9,26 @@
     <PackageReference Include="AutoBogus" Version="2.13.1" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.2" />
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
-    <PackageReference Include="Azure.ResourceManager" Version="1.9.0" />
+    <PackageReference Include="Azure.ResourceManager" Version="1.10.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.5.1" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.2.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
-    <PackageReference Include="Microsoft.Graph" Version="5.36.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.16.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.41.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.16.1" />
+    <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.16.1" />
     <PackageReference Include="OneOf" Version="3.0.263" />
-    <PackageReference Include="Riok.Mapperly" Version="3.2.0" />
+    <PackageReference Include="Riok.Mapperly" Version="3.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Because of an issue with the isolated worker the root exceptions from activities are not exposed. Therefor we explicitly capture and log the exceptions before they bubble up to the orchestrations.

https://github.com/Azure/azure-functions-durable-extension/issues/2476