### PR TITLE
Use traditional durable functions instead of class based

### DIFF
--- a/Kerbee/Functions/GetApplicationsActivity.cs
+++ b/Kerbee/Functions/GetApplicationsActivity.cs
@@ -4,20 +4,20 @@ using System.Threading.Tasks;
 using Kerbee.Graph;
 using Kerbee.Models;
 
-using Microsoft.DurableTask;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace Kerbee.Functions;
 
-[DurableTask(nameof(GetApplicationsActivity))]
 public class GetApplicationsActivity(
     ILogger<GetApplicationsActivity> logger,
-    IApplicationService applicationService) : TaskActivity<object, IEnumerable<Application>>
+    IApplicationService applicationService)
 {
     private readonly ILogger _logger = logger;
     private readonly IApplicationService _applicationService = applicationService;
 
-    public override async Task<IEnumerable<Application>> RunAsync(TaskActivityContext context, object input)
+    [Function(nameof(GetApplicationsActivity))]
+    public async Task<IEnumerable<Application>> RunAsync([ActivityTrigger] object input)
     {
         try
         {

--- a/Kerbee/Functions/GetExpiringCertificatesAndSecrets.cs
+++ b/Kerbee/Functions/GetExpiringCertificatesAndSecrets.cs
@@ -6,13 +6,12 @@ using Kerbee.Graph;
 using Kerbee.Models;
 using Kerbee.Options;
 
-using Microsoft.DurableTask;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Options;
 
 namespace Kerbee.Functions;
 
-[DurableTask(nameof(GetExpiringCertificatesAndSecrets))]
-public class GetExpiringCertificatesAndSecrets : TaskActivity<DateTime, IEnumerable<Application>>
+public class GetExpiringCertificatesAndSecrets
 {
     public GetExpiringCertificatesAndSecrets(
         IApplicationService applicationService,
@@ -25,7 +24,8 @@ public class GetExpiringCertificatesAndSecrets : TaskActivity<DateTime, IEnumera
     private readonly IApplicationService _applicationService;
     private readonly KerbeeOptions _options;
 
-    public override async Task<IEnumerable<Application>> RunAsync(TaskActivityContext context, DateTime expiryDate)
+    [Function(nameof(GetExpiringCertificatesAndSecrets))]
+    public async Task<IEnumerable<Application>> RunAsync([ActivityTrigger] DateTime expiryDate)
     {
         return await _applicationService.GetApplicationsAsync(expiryDate);
     }

--- a/Kerbee/Functions/PurgeExpiredKeysActivity.cs
+++ b/Kerbee/Functions/PurgeExpiredKeysActivity.cs
@@ -4,20 +4,20 @@ using System.Threading.Tasks;
 using Kerbee.Graph;
 using Kerbee.Models;
 
-using Microsoft.DurableTask;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace Kerbee.Functions;
 
-[DurableTask(nameof(PurgeExpiredKeysActivity))]
 public class PurgeExpiredKeysActivity(
     ILogger<PurgeExpiredKeysActivity> logger,
-    IApplicationService applicationService) : TaskActivity<Application, object>
+    IApplicationService applicationService)
 {
     private readonly ILogger _logger = logger;
     private readonly IApplicationService _applicationService = applicationService;
 
-    public override async Task<object> RunAsync(TaskActivityContext context, Application application)
+    [Function(nameof(PurgeExpiredKeysActivity))]
+    public async Task<object> RunAsync([ActivityTrigger] Application application)
     {
         try
         {

--- a/Kerbee/Functions/RenewKeyActivity.cs
+++ b/Kerbee/Functions/RenewKeyActivity.cs
@@ -4,20 +4,20 @@ using System.Threading.Tasks;
 using Kerbee.Graph;
 using Kerbee.Models;
 
-using Microsoft.DurableTask;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace Kerbee.Functions;
 
-[DurableTask(nameof(RenewKeyActivity))]
 public class RenewKeyActivity(
     ILogger<RenewKeyActivity> logger,
-    IApplicationService applicationService) : TaskActivity<Application, object>
+    IApplicationService applicationService)
 {
     private readonly ILogger _logger = logger;
     private readonly IApplicationService _applicationService = applicationService;
 
-    public override async Task<object> RunAsync(TaskActivityContext context, Application application)
+    [Function(nameof(RenewKeyActivity))]
+    public async Task<object> RunAsync([ActivityTrigger] Application application)
     {
         try
         {

--- a/Kerbee/Functions/UpdateApplicationsActivity.cs
+++ b/Kerbee/Functions/UpdateApplicationsActivity.cs
@@ -22,6 +22,7 @@ public class UpdateApplicationsActivity(
     {
         try
         {
+            _logger.LogInformation("Updating applications");
             await _applicationService.UpdateApplications();
             return new object();
         }

--- a/Kerbee/Functions/UpdateApplicationsActivity.cs
+++ b/Kerbee/Functions/UpdateApplicationsActivity.cs
@@ -3,26 +3,24 @@ using System.Threading.Tasks;
 
 using Kerbee.Graph;
 
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask;
 using Microsoft.Extensions.Logging;
 
 namespace Kerbee.Functions;
 
-[DurableTask(nameof(UpdateApplicationsActivity))]
 public class UpdateApplicationsActivity(
     IApplicationService applicationService,
-    ILogger<UpdateApplicationsActivity> logger) : TaskActivity<object, object>
+    ILogger<UpdateApplicationsActivity> logger)
 {
     private readonly IApplicationService _applicationService = applicationService;
     private readonly ILogger<UpdateApplicationsActivity> _logger = logger;
 
-    public override async Task<object> RunAsync(
-        TaskActivityContext context,
-        object input)
+    [Function(nameof(UpdateApplicationsActivity))]
+    public async Task<object> RunAsync([ActivityTrigger] object input)
     {
         try
         {
-            _logger.LogInformation("Updating applications");
             await _applicationService.UpdateApplications();
             return new object();
         }

--- a/Kerbee/Kerbee.csproj
+++ b/Kerbee/Kerbee.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
-    <PackageReference Include="Microsoft.DurableTask.Generators" Version="1.0.0-preview.1" />
     <PackageReference Include="Microsoft.Graph" Version="5.41.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.16.1" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.16.1" />
@@ -42,10 +41,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
-  </ItemGroup>
-  <Target Name="DeleteFiles" AfterTargets="Publish">
-    <Delete Files="$(PublishDir)System.Reactive.xml" />
-  </Target>
 </Project>

--- a/Kerbee/host.json
+++ b/Kerbee/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Information",
+      "default": "Warning",
       "Host.Results": "Error",
       "Function": "Error",
       "Host.Aggregator": "Warning",


### PR DESCRIPTION
The class based durable functions using the source generator for starting orchestrations and activities in a typed manner hasn't received much support in the last year. We've encountered various issues that could've been resolved by updating the NuGet versions. This makes it impossible to use the class based durable functions. Therefor we revert to the traditional durable functions instead.